### PR TITLE
Fix/user-stats

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -35,4 +35,10 @@ export class AuthController {
   async me(@CurrentUser() user: LogoutDto) {
     return this.authService.userStats(user.playerId);
   }
+
+  @Get('weeklyWinrate')
+  @UseGuards(PassportJwtGuard)
+  async weeklyWinrate(@CurrentUser() user: LogoutDto) {
+    return this.authService.weeklyWinrate(user.playerId);
+  }
 }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import { Injectable, Logger, ServiceUnavailableException, UnauthorizedException } from '@nestjs/common';
 import { playerTable } from '../shared/db/schema';
 import type { playerSelect } from '../shared/db/schema';
 import { Response } from 'express';
@@ -102,10 +102,7 @@ export class AuthService {
     return response.json(user);
   }
 
-  async verifyUser(
-    identifier: string,
-    password: string,
-  ): Promise<playerSelect> {
+  async verifyUser(identifier: string, password: string): Promise<playerSelect> {
     const normalized = identifier.trim();
     const user = (
       (await this.utilsService.findPlayersBy(
@@ -124,10 +121,7 @@ export class AuthService {
     return user;
   }
 
-  async verifyRefreshToken(
-    playerId: number,
-    refreshToken: string,
-  ): Promise<ResponseLoginDto> {
+  async verifyRefreshToken(playerId: number, refreshToken: string): Promise<ResponseLoginDto> {
     if (!refreshToken) {
       throw new UnauthorizedException('Refresh token is missing.');
     }
@@ -173,38 +167,26 @@ export class AuthService {
       throw new UnauthorizedException('User not found.');
     }
 
-    const stats = (
-      await this.utilsService.getGamesResCounts(user[0].playerId)
-    )[0];
+    const stats = (await this.utilsService.getGamesResCounts(user[0].playerId))[0];
     const lvlVal: number = stats?.totalWins ?? 0;
     const lossVal: number = stats?.totalLosses ?? 0;
     const drawVal: number = stats?.totalDraws ?? 0;
     const gameVal: number = stats?.totalGames ?? 0;
     const winrateVal: number = stats?.winRate ?? 0;
     
-    const color = (
-      await this.utilsService.getFavouriteColor(user[0].playerId)
-    )[0];
+    const color = (await this.utilsService.getFavouriteColor(user[0].playerId))[0];
     const colorVal: string = color?.playerColor ?? 'unknown';
 
-    const gm = (
-      await this.utilsService.getFavouriteGameMode(user[0].playerId)
-    )[0];
+    const gm = (await this.utilsService.getFavouriteGameMode(user[0].playerId))[0];
     const gameModeVal: string = gm?.gameMode ?? 'unknown';
 
-    const cws = (
-      await this.utilsService.getCurrentWinStreak(user[0].playerId)
-    )[0];
+    const cws = (await this.utilsService.getCurrentWinStreak(user[0].playerId))[0];
     const cwsVal: number = cws?.currentStreak ?? 0;
 
-    const lws = (
-      await this.utilsService.getLongestWinStreak(user[0].playerId)
-    )[0];
+    const lws = (await this.utilsService.getLongestWinStreak(user[0].playerId))[0];
     const lwsVal: number = lws?.longestStreak ?? 0;
 
-    const gameHistory = await this.utilsService.getGameHistory(
-      user[0].playerId,
-    );
+    const gameHistory = await this.utilsService.getGameHistory(user[0].playerId, 10);
     const historyVal = gameHistory ? gameHistory : undefined;
 
     return {
@@ -224,5 +206,23 @@ export class AuthService {
       gameHistoryList: historyVal,
       avatar: user[0].avatarUrl,
     };
+  }
+
+  async weeklyWinrate(playerId: number) {
+    try {
+    const user = (await this.utilsService.findPlayersBy(
+      'and',
+      undefined,
+      eq(playerTable.playerId, playerId),
+    )) as playerSelect[];
+    if (user.length === 0) {
+      throw new UnauthorizedException('User not found.');
+    }
+    const winrate = await this.utilsService.getWeeklyWinrate(user[0].playerId);
+    return winrate;
+    } catch (error) {
+      this.logger.error('Error fetching weekly winrate:', error);
+      throw new ServiceUnavailableException('Cannot fetch weekly winrate.');
+    }
   }
 }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -173,23 +173,15 @@ export class AuthService {
       throw new UnauthorizedException('User not found.');
     }
 
-    const lvl = (await this.utilsService.getTotalWins(user[0].playerId))[0];
-    const lvlVal: number = lvl?.totalWins ?? 0;
-
-    const loss = (await this.utilsService.getTotalLosses(user[0].playerId))[0];
-    const lossVal: number = loss?.totalLosses ?? 0;
-
-    const draws = (await this.utilsService.getTotalDraws(user[0].playerId))[0];
-    const drawVal: number = draws?.totalDraws ?? 0;
-
-    const gameNb = (
-      await this.utilsService.getTotalGamesPlayed(user[0].playerId)
+    const stats = (
+      await this.utilsService.getGamesResCounts(user[0].playerId)
     )[0];
-    const gameVal: number = gameNb?.totalGames ?? 0;
-
-    const wr = (await this.utilsService.getWinrate(user[0].playerId))[0];
-    const winrateVal: number = wr?.winrate ?? 0;
-
+    const lvlVal: number = stats?.totalWins ?? 0;
+    const lossVal: number = stats?.totalLosses ?? 0;
+    const drawVal: number = stats?.totalDraws ?? 0;
+    const gameVal: number = stats?.totalGames ?? 0;
+    const winrateVal: number = stats?.winRate ?? 0;
+    
     const color = (
       await this.utilsService.getFavouriteColor(user[0].playerId)
     )[0];

--- a/backend/src/shared/services/utils.func.service.ts
+++ b/backend/src/shared/services/utils.func.service.ts
@@ -8,7 +8,7 @@ import {
   participationInsert,
   participationTable,
 } from '../db/schema';
-import { and, or, eq, ne, sql, SQLWrapper, desc } from 'drizzle-orm';
+import { and, or, eq, ne, sql, SQLWrapper, desc, gte, lt } from 'drizzle-orm';
 import { SelectedFieldsFlat, PgTable } from 'drizzle-orm/pg-core';
 import { DatabaseService } from './db.service';
 import { Injectable } from '@nestjs/common';
@@ -583,7 +583,7 @@ export class UtilsService {
     return query;
   };
 
-  getGameHistory = async (playerId: number) => {
+  getGameHistory = async (playerId: number, nb: number) => {
     const allGames = this.Database.getDb()
       .select({
         gameId: participationTable.gameId,
@@ -591,6 +591,7 @@ export class UtilsService {
       .from(participationTable)
       .innerJoin(gameTable, eq(participationTable.gameId, gameTable.gameId))
       .where(eq(participationTable.playerId, playerId))
+      .limit(nb)
       .orderBy(desc(gameTable.gameCreatedAt))
       .as('all_games');
     const opponentsNamesQuery = this.Database.getDb()
@@ -629,4 +630,73 @@ export class UtilsService {
       .orderBy(desc(gameTable.gameCreatedAt));
     return query;
   };
+
+  getWeeklyWinrate = async (playerId: number) => {
+    const currentWeekStart = new Date();
+    currentWeekStart.setUTCHours(0, 0, 0, 0);
+    currentWeekStart.setUTCDate(
+      currentWeekStart.getUTCDate() - ((currentWeekStart.getUTCDay() + 6) % 7),
+    );
+    const nextWeekStart = new Date(currentWeekStart);
+    nextWeekStart.setUTCDate(nextWeekStart.getUTCDate() + 7);
+
+    const weeklyRows = await this.Database.getDb()
+      .select({
+        dayDate: sql<string>`DATE_TRUNC('day', ${gameTable.gameCreatedAt})::date`.as(
+          'dayDate',
+        ),
+        wins:
+          sql<number>`COUNT(*) FILTER (WHERE ${participationTable.playerResult} = 'WIN')::int`.as(
+            'wins',
+          ),
+        games:
+          sql<number>`COUNT(*) FILTER (WHERE ${participationTable.playerResult} <> 'PENDING')::int`.as(
+            'games',
+          ),
+      })
+      .from(participationTable)
+      .innerJoin(gameTable, eq(participationTable.gameId, gameTable.gameId))
+      .where(
+        and(
+          eq(participationTable.playerId, playerId),
+          gte(gameTable.gameCreatedAt, currentWeekStart),
+          lt(gameTable.gameCreatedAt, nextWeekStart),
+        ),
+      )
+      .groupBy(sql`DATE_TRUNC('day', ${gameTable.gameCreatedAt})`)
+      .orderBy(sql`DATE_TRUNC('day', ${gameTable.gameCreatedAt})`);
+
+    const byDate = new Map<string, { wins: number; games: number }>();
+    for (const row of weeklyRows) {
+      const dateIso = row.dayDate.slice(0, 10);
+      byDate.set(dateIso, { wins: row.wins, games: row.games });
+    }
+
+    let cumulativeWins = 0;
+    let cumulativeGames = 0;
+    const points: { dayIndex: number; date: string; winrate: number }[] = [];
+
+    for (let i = 0; i < 7; i++) {
+      const date = new Date(currentWeekStart);
+      date.setUTCDate(currentWeekStart.getUTCDate() + i);
+      const dateIso = date.toISOString().slice(0, 10);
+      const stats = byDate.get(dateIso) ?? { wins: 0, games: 0 };
+      cumulativeWins += stats.wins;
+      cumulativeGames += stats.games;
+
+      const winrate =
+        cumulativeGames === 0
+          ? 0
+          : Number(((cumulativeWins * 100) / cumulativeGames).toFixed(2));
+
+      points.push({ dayIndex: i + 1, date: dateIso, winrate });
+    }
+
+    return {
+      timezone: 'UTC',
+      weekStart: currentWeekStart.toISOString().slice(0, 10),
+      points,
+    };
+  };
+
 }

--- a/backend/src/shared/services/utils.func.service.ts
+++ b/backend/src/shared/services/utils.func.service.ts
@@ -365,28 +365,6 @@ export class UtilsService {
   };
 
   //miscellaneous functions
-  // query to calculate a player winrate depending on conditions  (=> [gameName, winrate])
-  getWinrate = async (playerId?: number) => {
-    let query = this.Database.getDb()
-      .select({
-        playerName: playerTable.playerName,
-        winrate: sql<number>`( COUNT(*) FILTER (WHERE ${participationTable.playerResult} = 'WIN') + 0.5 * COUNT(*) FILTER (WHERE ${participationTable.playerResult} = 'DRAW'))
-/ NULLIF(COUNT(*) FILTER (WHERE ${participationTable.playerResult} <> 'PENDING'), 0)::float`,
-      })
-      .from(participationTable)
-      .innerJoin(
-        playerTable,
-        eq(participationTable.playerId, playerTable.playerId),
-      )
-      .groupBy(playerTable.playerName);
-    if (playerId) {
-      query = query.where(
-        eq(participationTable.playerId, playerId),
-      ) as typeof query;
-    }
-    return query;
-  };
-
   //query to calculate average number of moves to win for a player
   getAverageWinMoves = async (playerId?: number) => {
     let query = this.Database.getDb()
@@ -454,12 +432,16 @@ export class UtilsService {
     return query;
   };
 
-  //query to return total number of games played by a player
-  getTotalGamesPlayed = async (playerId?: number) => {
+  //query to return total number of games, nb of wins, loss and draws for a player
+  getGamesResCounts = async (playerId?: number) => {
     let query = this.Database.getDb()
       .select({
         playerName: playerTable.playerName,
+        winRate: sql<number>`( COUNT(*) FILTER (WHERE ${participationTable.playerResult} = 'WIN') + 0.5 * COUNT(*) FILTER (WHERE ${participationTable.playerResult} = 'DRAW')) / NULLIF(COUNT(*) FILTER (WHERE ${participationTable.playerResult} <> 'PENDING'), 0)::float`,
         totalGames: sql<number>`COUNT(${participationTable.gameId})::int`,
+        totalWins: sql<number>`COUNT(*) FILTER (WHERE ${participationTable.playerResult} = 'WIN')::int`,
+        totalLosses: sql<number>`COUNT(*) FILTER (WHERE ${participationTable.playerResult} = 'LOSE')::int`,
+        totalDraws: sql<number>`COUNT(*) FILTER (WHERE ${participationTable.playerResult} = 'DRAW')::int`,
       })
       .from(playerTable)
       .leftJoin(
@@ -469,90 +451,6 @@ export class UtilsService {
       .groupBy(playerTable.playerName, playerTable.playerId);
     if (playerId) {
       query = query.where(eq(playerTable.playerId, playerId)) as typeof query;
-    }
-    return query;
-  };
-
-  //query to return total number of wins by a player
-  getTotalWins = async (playerId?: number) => {
-    let query = this.Database.getDb()
-      .select({
-        playerName: playerTable.playerName,
-        totalWins: sql<number>`COALESCE(COUNT(*), 0)::int`,
-      })
-      .from(participationTable)
-      .innerJoin(
-        playerTable,
-        eq(participationTable.playerId, playerTable.playerId),
-      )
-      .groupBy(playerTable.playerName, playerTable.playerId);
-    if (playerId) {
-      query = query.where(
-        and(
-          eq(participationTable.playerId, playerId),
-          eq(participationTable.playerResult, 'WIN'),
-        ),
-      ) as typeof query;
-    } else {
-      query = query.where(
-        eq(participationTable.playerResult, 'WIN'),
-      ) as typeof query;
-    }
-    return query;
-  };
-
-  //query to return total number of losses by a player
-  getTotalLosses = async (playerId?: number) => {
-    let query = this.Database.getDb()
-      .select({
-        playerName: playerTable.playerName,
-        totalLosses: sql<number>`COALESCE(COUNT(*), 0)::int`,
-      })
-      .from(participationTable)
-      .innerJoin(
-        playerTable,
-        eq(participationTable.playerId, playerTable.playerId),
-      )
-      .groupBy(playerTable.playerName, playerTable.playerId);
-    if (playerId) {
-      query = query.where(
-        and(
-          eq(participationTable.playerId, playerId),
-          eq(participationTable.playerResult, 'LOSE'),
-        ),
-      ) as typeof query;
-    } else {
-      query = query.where(
-        eq(participationTable.playerResult, 'LOSE'),
-      ) as typeof query;
-    }
-    return query;
-  };
-
-  //query to return total number of draws by a player
-  getTotalDraws = async (playerId?: number) => {
-    let query = this.Database.getDb()
-      .select({
-        playerName: playerTable.playerName,
-        totalDraws: sql<number>`COALESCE(COUNT(*), 0)::int`,
-      })
-      .from(participationTable)
-      .innerJoin(
-        playerTable,
-        eq(participationTable.playerId, playerTable.playerId),
-      )
-      .groupBy(playerTable.playerName, playerTable.playerId);
-    if (playerId) {
-      query = query.where(
-        and(
-          eq(participationTable.playerId, playerId),
-          eq(participationTable.playerResult, 'DRAW'),
-        ),
-      ) as typeof query;
-    } else {
-      query = query.where(
-        eq(participationTable.playerResult, 'DRAW'),
-      ) as typeof query;
     }
     return query;
   };


### PR DESCRIPTION
## 📝 Description
This pull request refactors how player game statistics are retrieved and calculated in the backend. The main improvement is consolidating multiple database queries for individual statistics (wins, losses, draws, games played, and win rate) into a single, more efficient query. This reduces database load and simplifies the codebase.

**Refactoring and Query Consolidation:**
* Added a new method `getGamesResCounts` in `utils.func.service.ts` that retrieves total games, wins, losses, draws, and win rate for a player in a single query, replacing several individual methods.
* Removed the now-redundant methods: `getTotalWins`, `getTotalLosses`, `getTotalDraws`, `getTotalGamesPlayed`, and `getWinrate` from `utils.func.service.ts`.

**Service Usage Update:**
* Updated `auth.service.ts` to use the new consolidated `getGamesResCounts` method for retrieving player statistics, replacing multiple calls to the old individual methods.

## 🎯 Type de changement
- [x] 🐛 Correction de bug (Bug fix)
- [ ] ✨ Nouvelle fonctionnalité (New feature)
- [ ] 🎨 Refactoring (Pas de changement fonctionnel, juste du code plus propre)
- [ ] 📚 Documentation

## 🧪 Comment tester cette PR ?
<!-- Décris les étapes exactes pour que je puisse vérifier que ça marche. -->
1. Launch `docker compose --profile dev up -d`
2. Login a user with REST Thundercat or Postman API 
3. Send HTTP request with valid access token to https:localhost/api/auth/me 
4. Check stats in object returned