### PR TITLE
Feat/leaderboard

### DIFF
--- a/backend/src/shared/services/utils.func.service.ts
+++ b/backend/src/shared/services/utils.func.service.ts
@@ -980,4 +980,29 @@ export class UtilsService {
       );
     }
   };
+
+  getLeaderboard = async () => {
+    try {
+      let query = this.Database.getDb()
+        .select({
+          playerId: playerTable.playerId,
+          playerName: playerTable.playerName,
+          playerLevel: sql<number>`COUNT(*) FILTER (WHERE ${participationTable.playerResult} = 'WIN')::int`.as('playerLevel'),
+        })
+        .from(playerTable)
+        .leftJoin(
+          participationTable,
+          eq(participationTable.playerId, playerTable.playerId),
+        )
+        .groupBy(playerTable.playerId, playerTable.playerName);
+
+      const leaderboard = await query.orderBy(desc(sql`playerLevel`));
+      return leaderboard;
+    } catch (error) {
+      this.throwDbUnavailable(
+        error,
+        'Database error during leaderboard retrieval.',
+      );
+    }
+  };
 }

--- a/backend/src/shared/services/utils.func.service.ts
+++ b/backend/src/shared/services/utils.func.service.ts
@@ -983,11 +983,14 @@ export class UtilsService {
 
   getLeaderboard = async () => {
     try {
+      const playerLevel = sql<number>`COUNT(*) FILTER (WHERE ${participationTable.playerResult} = 'WIN')::int`.as(
+        'playerLevel',
+      );
       let query = this.Database.getDb()
         .select({
           playerId: playerTable.playerId,
           playerName: playerTable.playerName,
-          playerLevel: sql<number>`COUNT(*) FILTER (WHERE ${participationTable.playerResult} = 'WIN')::int`.as('playerLevel'),
+          playerLevel,
         })
         .from(playerTable)
         .leftJoin(
@@ -996,7 +999,7 @@ export class UtilsService {
         )
         .groupBy(playerTable.playerId, playerTable.playerName);
 
-      const leaderboard = await query.orderBy(desc(sql`playerLevel`));
+      const leaderboard = await query.orderBy(desc(playerLevel));
       return leaderboard;
     } catch (error) {
       this.throwDbUnavailable(

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -66,4 +66,10 @@ export class UsersController {
   async weeklyWinrate(@CurrentUser() user: { playerId: number }) {
     return this.UserService.weeklyWinrate(user.playerId);
   }
+
+  @Get('leaderboard')
+  @UseGuards(PassportJwtGuard)
+  async leaderboard() {
+    return this.UserService.getLeaderboard();
+  }
 }

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -37,6 +37,22 @@ type UserStatsResponse = {
   gameHistoryList?: any[]; // Adjust type based on actual game history structure
 };
 
+type weeklyWinrateResponse = {
+  timezone: string;
+  weekStart: string;
+  points: {
+    dayIndex: number;
+    date: string;
+    winrate: number;
+  }[];
+};
+
+type leaderboardEntry = {
+  playerId: number;
+  playerName: string;
+  playerLevel: number;
+};
+
 @Injectable()
 export class UsersService {
   constructor(
@@ -77,7 +93,7 @@ export class UsersService {
     })) as { [x: string]: unknown }[];
   }
 
-  async getDataUser(playerId: number) {
+  async getDataUser(playerId: number): Promise<playerSelect> {
     const player = (await this.utilsService.findPlayersBy(
       'and',
       {
@@ -95,7 +111,7 @@ export class UsersService {
     return player[0];
   }
 
-  async deleteUserbyId(playerId: number, response: Response) {
+  async deleteUserbyId(playerId: number, response: Response): Promise<void> {
     const user = (await this.utilsService.findPlayersBy(
       'and',
       undefined,
@@ -289,7 +305,7 @@ export class UsersService {
     } as UserStatsResponse;
   }
 
-  async weeklyWinrate(playerId: number) {
+  async weeklyWinrate(playerId: number): Promise<weeklyWinrateResponse> {
     try {
       const user = (await this.utilsService.findPlayersBy(
         'and',
@@ -310,4 +326,8 @@ export class UsersService {
       );
     }
   }
+
+    async getLeaderboard(): Promise<leaderboardEntry[]> {
+      return this.utilsService.getLeaderboard();
+    }
 }


### PR DESCRIPTION
## 📝 Description
This pull request introduces a new leaderboard feature to the backend, allowing users to retrieve a ranked list of players based on their win count. The main changes include the implementation of the leaderboard logic in the utility and user service layers, the addition of a new API endpoint, and the definition of new types for response consistency. Several existing methods were also updated to include more precise type annotations.

**Leaderboard Feature Implementation:**
Added a `getLeaderboard` method to `UtilsService` that queries the database for player win counts, groups results by player, and orders them by the number of wins to produce a leaderboard.
Added a `getLeaderboard` method to `UsersService` that calls the utility method and returns the leaderboard data.
Introduced a new API endpoint `GET /users/leaderboard` in `UsersController`, protected by JWT authentication, which returns the leaderboard data.

**Type Definitions and Type Safety Improvements:**
Defined new TypeScript types: `leaderboardEntry` for leaderboard responses and `weeklyWinrateResponse` for weekly winrate responses, improving type safety and API documentation.
Updated method signatures in `UsersService` to specify return types for `getDataUser`, `deleteUserbyId`, and `weeklyWinrate` for better type safety and clarity.

## 🎯 Type de changement
- [ ] 🐛 Correction de bug (Bug fix)
- [x] ✨ Nouvelle fonctionnalité (New feature)
- [ ] 🎨 Refactoring (Pas de changement fonctionnel, juste du code plus propre)
- [ ] 📚 Documentation

## 🧪 Comment tester cette PR ?
1. Launch `docker compose --profile dev up --build`
2. Use Thundercat REST API:
- `POST https://localhost/api/auth/login` with valid credentials
- `GET https://localhost/api/users/leaderboard` request with valid access token in header
- check response body
